### PR TITLE
Refactor sarifReportFinder.ts to use promises when reading a directory

### DIFF
--- a/src/sarif/SarifReportFinder.ts
+++ b/src/sarif/SarifReportFinder.ts
@@ -28,16 +28,14 @@ export default class SarifReportFinder {
     if (fs.lstatSync(dir).isDirectory()) {
       console.log(`  is a directory, looking for files`);
 
-      const files = fs.readdirSync(dir) // TODO use promises here
-        .filter(f => f.endsWith('.sarif'))
-        .map(f => path.resolve(dir, f));
-
-      console.log(`  SARIF files detected: ${JSON.stringify(files)}`);
-      if (files) {
-        files.forEach(f => {
-          promises.push(loadFileContents(f));
-        });
-      }
+    fs.promises.readdir(dir)
+      .then(files => {
+        files
+          .filter(f => f.endsWith('.sarif'))
+          .map(f => path.resolve(dir, f));
+        console.log(`    SARIF files detected: ${JSON.stringify(files)}`)
+        files.forEach(f => promises.push(loadFileContents(f)));
+      })
     }
 
     if (promises.length > 0) {

--- a/src/sarif/SarifReportFinder.ts
+++ b/src/sarif/SarifReportFinder.ts
@@ -30,11 +30,11 @@ export default class SarifReportFinder {
 
     fs.promises.readdir(dir)
       .then(files => {
-        files
+        const sarifFiles = files
           .filter(f => f.endsWith('.sarif'))
           .map(f => path.resolve(dir, f));
-        console.log(`    SARIF files detected: ${JSON.stringify(files)}`)
-        files.forEach(f => promises.push(loadFileContents(f)));
+        console.log(`    SARIF files detected: ${JSON.stringify(sarifFiles)}`)
+        sarifFiles.forEach(f => promises.push(loadFileContents(f)));
       })
     }
 


### PR DESCRIPTION
Hi, 

This changes the reading of a directory for SARIF files to use promises, which allows us to read it asynchronously. 

This also coincidentally fixes a bug where running the binary in Windows while using the option `--sarif-directory ".\"` caused the program to log "SARIF files detected: []" regardless of what it actually found (the program seems to work correctly despite it logging erroneously). I suspect it has something to do with the way something else in the program parses `".\"` but I didn't investigate further since it went away after exchanging `fs.readdirSync() `for` fs.promises.readdir()`.

Your fork seems to be more actively maintained than the base repository from Peter Murray, so that's why I built on top of your work :)